### PR TITLE
Enable flakes

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -24,6 +24,11 @@
   nix.buildCores = 32;
   nix.maxJobs = 64;
   nix.trustedUsers = [ "root" "@wheel" "jon" "nixpkgs-update" "tim" ];
+  # Flake support
+  nix.package = pkgs.nixUnstable;
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
 
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;


### PR DESCRIPTION
Going by [these instructions](https://nixos.wiki/wiki/Flakes), I'm updating the config to enable flakes.
Will need a `nixos-rebuild switch` afterwards