### PR TITLE
config: disable swapping

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -31,6 +31,7 @@
   '';
 
   # Use the systemd-boot EFI boot loader.
+  boot.kernel.sysctl."vm.swappiness" = 0;
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.initrd.kernelModules = [ "zfs" ];


### PR DESCRIPTION
The system currently does not have any swap configured. As such, we
should be using sysctl to inform the kernel that no swapping may happen.
