### PR TITLE
feat: enable sshServe for users

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   imports =
@@ -29,6 +29,12 @@
   nix.extraOptions = ''
     experimental-features = nix-command flakes
   '';
+
+  nix.sshServe = {
+    enable = true;
+    keys = lib.concatMap (u: u.openssh.authorizedKeys.keys) config.users.users;
+    protocol = "ssh-ng";
+  };
 
   # Use the systemd-boot EFI boot loader.
   boot.kernel.sysctl."vm.swappiness" = 0;


### PR DESCRIPTION
This allows users to fetch packages from the host as if it were a substituter.

It essentially just makes the workflow of build on the box and then `nix copy`'ing back more seamless.

The better alternative from a usability POV is to configure it as a remote
builder, but that's extremely bandwidth consuming so I don't think it's a good
idea.
