### PR TITLE
refactor: use stable Nix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -27,7 +27,6 @@
   nix.maxJobs = 80;
   nix.trustedUsers = [ "root" "@wheel" "jon" "nixpkgs-update" "tim" "jtojnar" ];
   # Flake support
-  nix.package = pkgs.nixUnstable;
   nix.extraOptions = ''
     experimental-features = nix-command flakes
   '';


### PR DESCRIPTION
We used to use `nixUnstable` for flake support, but that has since been
incorporated into Nix 2.4.0 and later releases.

Let's just use stable Nix (2.6.0 at the time of writing) to avoid Unstable
issues.
