### PR TITLE
downgrade to nix 2.7

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -26,7 +26,7 @@
   nix.buildCores = 32;
   nix.maxJobs = 40;
   nix.trustedUsers = [ "root" "@wheel" "jon" "nixpkgs-update" "tim" "jtojnar" ];
-  nix.package = pkgs.nixVersions.unstable;
+  nix.package = pkgs.nixVersions.nix_2_7;
   # Flake support
   nix.extraOptions = ''
     experimental-features = nix-command flakes


### PR DESCRIPTION
workaround for https://github.com/NixOS/nix/issues/6572

nix is broken since https://github.com/NixOS/nix/pull/6227 = nix 2.8