### PR TITLE
refactor: use latest stable Nix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -26,7 +26,6 @@
   nix.buildCores = 32;
   nix.maxJobs = 40;
   nix.trustedUsers = [ "root" "@wheel" "jon" "nixpkgs-update" "tim" "jtojnar" ];
-  nix.package = pkgs.nixVersions.nix_2_7;
   # Flake support
   nix.extraOptions = ''
     experimental-features = nix-command flakes


### PR DESCRIPTION
I'm not sure why 2.7 was being pinned, but this should enable some of the newer
features :)
