### PR TITLE
flake.nix: add dwarffs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,17 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   #inputs.nixpkgs.url = "path:/home/jon/projects/nixpkgs";
   inputs.hydra.url = "github:NixOS/hydra";
+  inputs.dwarffs.url = "github:edolstra/dwarffs";
 
-  outputs = { self, nixpkgs, hydra }: {
+  outputs = { self, nixpkgs, hydra, dwarffs }: {
 
     nixosConfigurations.server = nixpkgs.lib.nixosSystem rec {
       system = "x86_64-linux";
       modules = [
         ./configuration.nix
+        # https://github.com/edolstra/dwarffs
+        # auto-fetch debug info files for gdb
+        dwarffs.nixosModules.dwarffs
       ];
       specialArgs = {
         inherit (hydra.packages.${system}) hydra;


### PR DESCRIPTION
https://github.com/edolstra/dwarffs

edit: not sure how useful this is.
i tried to debug `nix` with these dwarf files, but `gdb` keeps saying `No symbol table`