### PR TITLE
Add build directory and new cachix substituter

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -241,14 +241,17 @@
       sandbox = true;
       cores = 32;
       max-jobs = 40;
+      build-dir = "/tmp";
 
       substituters = [
         "https://cache.nixos.org"
         "https://nix-community.cachix.org"
+        "https://ekala-corepkgs.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+        "ekala-corepkgs.cachix.org-1:DcZV+vegWoEzacbSdXFXU4S7728C0eS9RfGpKeyHd6w="
       ];
       trusted-users = [
         "root"


### PR DESCRIPTION
 Nix build sandboxes were backed by the default /nix/var/nix/builds directory on the nearly full root filesystem, despite /nix/store being mounted on a separate disk with ample space. Concurrent CI builds exhausted /, causing builders such as GCC and Go to fail with No space left on device and secondary missing-file errors. This change moves build-dir to the dedicated /tmp tmpfs to prevent recurrence.