### PR TITLE
Reduce nrBuildUsers from 450 to 128

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -233,7 +233,7 @@
 
   # Nix&Nixpkgs {{{
   nix = {
-    nrBuildUsers = 450;
+    nrBuildUsers = 128;
 
     settings = {
       allowed-uris = ["git+https://" "https://" "github.com:jonringer/"];


### PR DESCRIPTION
nrBuildUsers is kinda legacy setting from times when nix cannot wait for users to become available instead of failing. Since nix 2.4 it is no longer the case, see https://github.com/NixOS/nix/pull/3564.

nrBuildUsers 128 means that no more than 128 local derivations can actively buding concurrently, nix.settings.max-jobs is a limit per "nix-build request", so actually possible limit was 450 nix build jobs at the same time, created by multiple connected nix clients. 128 should be enought for most cases